### PR TITLE
Python3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-syntax: glob
 *.orig
 *.rej
 *~
@@ -18,6 +17,3 @@ lib/libopenzwave.cpp
 debian/python-openzwave
 zwcfg_*
 install.files
-
-syntax: regexp
-.*\#.*\#$

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "openzwave"]
+	path = openzwave
+	url = https://github.com/OpenZWave/open-zwave.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM buildpack-deps:jessie
 MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
 
-# First install command is common packages, 2nd is Python 2 specific.
+# First install command is common packages, Python 2, Python 3.
 RUN apt-get update && \
     apt-get install -y libudev-dev cython3 && \
     apt-get install -y python-dev python-pip && \
+    apt-get install -y python3-setuptools python3-pip && \
     pip install cython && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM buildpack-deps:jessie
+MAINTAINER Paulus Schoutsen <Paulus@PaulusSchoutsen.nl>
+
+# First install command is common packages, 2nd is Python 2 specific.
+RUN apt-get update && \
+    apt-get install -y libudev-dev cython3 && \
+    apt-get install -y python-dev python-pip && \
+    pip install cython && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+CMD [ "/bin/bash" ]

--- a/INSTALL_DOCKER.txt
+++ b/INSTALL_DOCKER.txt
@@ -1,0 +1,25 @@
+Docker installation instructions
+--------------------------------
+
+Setting up a development environment is as easy as running:
+
+  docker build -t python-openzwave .
+
+This will build the image 'python-openzwave' with the right dependencies installed for building and installing Python Open Z-Wave.
+
+To enter the development environment, run the following command:
+(Replace /dev/ttyUSB0 with the path to your Z-Wave USB stick.)
+
+  docker run \
+    --device=/dev/ttyUSB0:/zwaveusbstick:rwm \
+    -v `pwd`:/usr/src/app \
+    -t -i python-openzwave
+
+This will open a shell in a linux environment. You are now ready to develop!
+
+To build and install, run:
+
+  ./compile.sh
+  ./install.sh
+
+Enjoy!

--- a/INSTALL_DOCKER.txt
+++ b/INSTALL_DOCKER.txt
@@ -17,9 +17,14 @@ To enter the development environment, run the following command:
 
 This will open a shell in a linux environment. You are now ready to develop!
 
-To build and install, run:
+To build and install for Python 2, run:
 
   ./compile.sh
   ./install.sh
+
+To build and install for Python 3, run:
+
+  ./compile.sh --python3
+  ./install.sh --python3
 
 Enjoy!

--- a/api/controller.py
+++ b/api/controller.py
@@ -24,7 +24,7 @@ You should have received a copy of the GNU General Public License
 along with python-openzwave. If not, see http://www.gnu.org/licenses.
 
 """
-from louie import dispatcher, All
+from .util import dispatcher
 import logging
 import libopenzwave
 import openzwave

--- a/api/group.py
+++ b/api/group.py
@@ -96,7 +96,7 @@ class ZWaveGroup(ZWaveObject):
         :rtype: int
 
         """
-        return self._network.manager.getGroupLabel(self.home_id, self._node_id, self.index)
+        return self._network.manager.getGroupLabel(self.home_id, self._node_id, self.index).decode("UTF-8")
 
     @property
     def max_associations(self):

--- a/api/network.py
+++ b/api/network.py
@@ -26,7 +26,7 @@ along with python-openzwave. If not, see http://www.gnu.org/licenses.
 from collections import namedtuple
 import thread
 import time
-from louie import dispatcher, All
+from .util import dispatcher
 import logging
 import threading
 import libopenzwave
@@ -309,7 +309,7 @@ class ZWaveNetwork(ZWaveObject):
         """
         logging.debug("Start network.")
         self._manager.addWatcher(self.zwcallback)
-        self._manager.addDriver(self._options.device)
+        self._manager.addDriver(self._options.device.encode("UTF-8"))
 
     def stop(self, fire=True):
         """
@@ -334,7 +334,7 @@ class ZWaveNetwork(ZWaveObject):
             self._semaphore_nodes.acquire()
             self._manager.removeWatcher(self.zwcallback)
             time.sleep(1.0)
-            self._manager.removeDriver(self._options.device)
+            self._manager.removeDriver(self._options.device.encode("UTF-8"))
             self.nodes = None
             self._state = self.STATE_STOPPED
             if fire :
@@ -579,8 +579,8 @@ class ZWaveNetwork(ZWaveObject):
         :rtype: ZWaveValue
 
         """
-        for node in self.nodes.itervalues():
-            for val in node.values.itervalues() :
+        for node in self.nodes.values():
+            for val in node.values.values() :
                 if val.id_on_network == id_on_network:
                     return val
         return None

--- a/api/node.py
+++ b/api/node.py
@@ -93,7 +93,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeName(self.home_id, self.object_id)
+        return self._network.manager.getNodeName(self.home_id, self.object_id).decode("UTF-8")
 
     @name.setter
     def name(self, value):
@@ -104,7 +104,7 @@ class ZWaveNode( ZWaveObject,
         :type value: str
 
         """
-        self._network.manager.setNodeName(self.home_id, self.object_id, value)
+        self._network.manager.setNodeName(self.home_id, self.object_id, value.encode("UTF-8"))
 
     @property
     def location(self):
@@ -114,7 +114,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeLocation(self.home_id, self.object_id)
+        return self._network.manager.getNodeLocation(self.home_id, self.object_id).decode("UTF-8")
 
     @location.setter
     def location(self, value):
@@ -125,7 +125,7 @@ class ZWaveNode( ZWaveObject,
         :type value: str
 
         """
-        self._network.manager.setNodeLocation(self.home_id, self.object_id, value)
+        self._network.manager.setNodeLocation(self.home_id, self.object_id, value.encode("UTF-8"))
 
     @property
     def product_name(self):
@@ -135,7 +135,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeProductName(self.home_id, self.object_id)
+        return self._network.manager.getNodeProductName(self.home_id, self.object_id).decode("UTF-8")
 
     @product_name.setter
     def product_name(self, value):
@@ -146,7 +146,7 @@ class ZWaveNode( ZWaveObject,
         :type value: str
 
         """
-        self._network.manager.setNodeProductName(self.home_id, self.object_id, value)
+        self._network.manager.setNodeProductName(self.home_id, self.object_id, value.encode("UTF-8"))
 
     @property
     def product_type(self):
@@ -156,7 +156,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeProductType(self.home_id, self.object_id)
+        return self._network.manager.getNodeProductType(self.home_id, self.object_id).decode("UTF-8")
 
     @property
     def product_id(self):
@@ -166,7 +166,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeProductId(self.home_id, self.object_id)
+        return self._network.manager.getNodeProductId(self.home_id, self.object_id).decode("UTF-8")
 
     @property
     def capabilities(self):
@@ -277,7 +277,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.COMMAND_CLASS_DESC[class_id]
+        return self._network.manager.COMMAND_CLASS_DESC[class_id].decode("UTF-8")
 
     def get_command_class_genres(self):
         """
@@ -431,6 +431,8 @@ class ZWaveNode( ZWaveObject,
         :rtype: bool
 
         """
+        value = value.encode("UTF-8")
+
         if field == "name":
             self.name=value
         elif field == "location":
@@ -459,7 +461,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeManufacturerId(self.home_id, self.object_id)
+        return self._network.manager.getNodeManufacturerId(self.home_id, self.object_id).decode("UTF-8")
 
     @property
     def manufacturer_name(self):
@@ -469,7 +471,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: str
 
         """
-        return self._network.manager.getNodeManufacturerName(self.home_id, self.object_id)
+        return self._network.manager.getNodeManufacturerName(self.home_id, self.object_id).decode("UTF-8")
 
     @manufacturer_name.setter
     def manufacturer_name(self, value):
@@ -480,7 +482,7 @@ class ZWaveNode( ZWaveObject,
         :type value: str
 
         """
-        self._network.manager.setNodeManufacturerName(self.home_id, self.object_id, value)
+        self._network.manager.setNodeManufacturerName(self.home_id, self.object_id, value.encode("UTF-8"))
 
     @property
     def generic(self):
@@ -765,7 +767,7 @@ class ZWaveNode( ZWaveObject,
         :rtype: string
 
         """
-        return self._network.manager.getNodeQueryStage(self.home_id, self.object_id)
+        return self._network.manager.getNodeQueryStage(self.home_id, self.object_id).decode("UTF-8")
 
     @property
     def isReady(self):
@@ -805,4 +807,4 @@ class ZWaveNode( ZWaveObject,
         Get a human-readable label describing the node
         :rtype: str
         """
-        return self._network.manager.getNodeType(self.home_id, self.object_id)
+        return self._network.manager.getNodeType(self.home_id, self.object_id).decode("UTF-8")

--- a/api/option.py
+++ b/api/option.py
@@ -84,7 +84,11 @@ class ZWaveOption(libopenzwave.PyOptions):
         except:
             raise ZWaveException("Can't find user directory %s" % user_path)
         self._cmd_line = cmd_line
-        self.create(self._config_path, self._user_path, self._cmd_line)
+
+        self.create(
+            self._config_path.encode("UTF-8"),
+            self._user_path.encode("UTF-8"),
+            self._cmd_line.encode("UTF-8"))
 
     def set_log_file(self, logfile):
         """
@@ -94,7 +98,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type logfile: str
 
         """
-        return self.addOptionString("LogFileName", logfile, False)
+        return self.addOptionStringUTF8("LogFileName", logfile, False)
 
     def set_logging(self, status):
         """
@@ -104,7 +108,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("Logging", status)
+        return self.addOptionBoolUTF8("Logging", status)
 
     def set_append_log_file(self, status):
         """
@@ -114,7 +118,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("AppendLogFile", status)
+        return self.addOptionBoolUTF8("AppendLogFile", status)
 
     def set_console_output(self, status):
         """
@@ -124,7 +128,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("ConsoleOutput", status)
+        return self.addOptionBoolUTF8("ConsoleOutput", status)
 
     def set_save_log_level(self, level):
         """
@@ -146,7 +150,7 @@ class ZWaveOption(libopenzwave.PyOptions):
             * 'Internal':"Used only within the log class (uses existing timestamp, etc.)"
 
         """
-        return self.addOptionInt("SaveLogLevel", PyLogLevels[level])
+        return self.addOptionIntUTF8("SaveLogLevel", PyLogLevels[level])
 
     def set_queue_log_level(self, level):
         """
@@ -168,7 +172,7 @@ class ZWaveOption(libopenzwave.PyOptions):
             * 'Internal':"Used only within the log class (uses existing timestamp, etc.)"
 
         """
-        return self.addOptionInt("QueueLogLevel", PyLogLevels[level])
+        return self.addOptionIntUTF8("QueueLogLevel", PyLogLevels[level])
 
     def set_dump_trigger_level(self, level):
         """
@@ -190,7 +194,7 @@ class ZWaveOption(libopenzwave.PyOptions):
             * 'Internal':"Used only within the log class (uses existing timestamp, etc.)"
 
         """
-        return self.addOptionInt("DumpTriggerLevel", PyLogLevels[level])
+        return self.addOptionIntUTF8("DumpTriggerLevel", PyLogLevels[level])
 
     def set_associate(self, status):
         """
@@ -200,7 +204,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("Associate", status)
+        return self.addOptionBoolUTF8("Associate", status)
 
     def set_exclude(self, commandClass):
         """
@@ -210,7 +214,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type commandClass: str
 
         """
-        return self.addOptionString("Exclude", commandClass, True)
+        return self.addOptionStringUTF8("Exclude", commandClass, True)
 
     def set_include(self, commandClass):
         """
@@ -220,7 +224,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type commandClass: str
 
         """
-        return self.addOptionString("Include", commandClass, True)
+        return self.addOptionStringUTF8("Include", commandClass, True)
 
     def set_notify_transactions(self, status):
         """
@@ -230,7 +234,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("NotifyTransactions", status)
+        return self.addOptionBoolUTF8("NotifyTransactions", status)
 
     def set_interface(self, port):
         """
@@ -240,7 +244,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type port: str
 
         """
-        return self.addOptionString("Interface", port, True)
+        return self.addOptionStringUTF8("Interface", port, True)
 
     def set_save_configuration(self, status):
         """
@@ -250,7 +254,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("SaveConfiguration", status)
+        return self.addOptionBoolUTF8("SaveConfiguration", status)
 
     def set_driver_max_attempts(self, attempts):
         """
@@ -260,7 +264,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type attempts: int
 
         """
-        return self.addOptionInt("DriverMaxAttempts", attempts)
+        return self.addOptionIntUTF8("DriverMaxAttempts", attempts)
 
     def set_poll_interval(self, interval):
         """
@@ -270,7 +274,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type interval: int
 
         """
-        return self.addOptionInt("PollInterval", interval)
+        return self.addOptionIntUTF8("PollInterval", interval)
 
     def set_interval_between_polls(self, status):
         """
@@ -280,7 +284,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("IntervalBetweenPolls", status)
+        return self.addOptionBoolUTF8("IntervalBetweenPolls", status)
 
     def set_suppress_value_refresh(self, status):
         """
@@ -290,7 +294,7 @@ class ZWaveOption(libopenzwave.PyOptions):
         :type status: bool
 
         """
-        return self.addOptionBool("SuppressValueRefresh", status)
+        return self.addOptionBoolUTF8("SuppressValueRefresh", status)
 
     @property
     def device(self):
@@ -321,3 +325,14 @@ class ZWaveOption(libopenzwave.PyOptions):
 
         """
         return self._user_path
+
+    def addOptionIntUTF8(self, option, value):
+        return self.addOptionInt(option.encode("UTF-8"), value)
+
+    def addOptionBoolUTF8(self, option, value):
+        return self.addOptionBool(option.encode("UTF-8"), value)
+
+    def addOptionStringUTF8(self, option, value, someBool):
+        """ Add an UTF-8 option string. """
+        return self.addOptionString(
+            option.encode("UTF-8"), value.encode("UTF-8"), someBool)

--- a/api/scene.py
+++ b/api/scene.py
@@ -30,6 +30,7 @@ import time
 import openzwave
 import logging
 from openzwave.object import ZWaveObject
+from .util import isstr
 
 logging.getLogger('openzwave').addHandler(logging.NullHandler())
 
@@ -80,7 +81,7 @@ class ZWaveScene(ZWaveObject):
         :rtype: str
 
         """
-        return self._network.manager.getSceneLabel(self.object_id)
+        return self._network.manager.getSceneLabel(self.object_id).decode("UTF-8")
 
     @label.setter
     def label(self, value):
@@ -91,7 +92,7 @@ class ZWaveScene(ZWaveObject):
         :type value: str
 
         """
-        self._network.manager.setSceneLabel(self.object_id, value)
+        self._network.manager.setSceneLabel(self.object_id, value.encode("UTF-8"))
 
     def create(self, label=None):
         """
@@ -108,7 +109,7 @@ class ZWaveScene(ZWaveObject):
         if scene_id != 0 :
             self._object_id = scene_id
             if label is not None:
-                self.label = label
+                self.label = label.encode("UTF-8")
         return scene_id
 
     def add_value(self, value_id, value_data):
@@ -121,6 +122,9 @@ class ZWaveScene(ZWaveObject):
         :type value_data: variable
 
         """
+        if isstr(value_data):
+            value_data = value_data.encode("UTF-8")
+
         ret = self._network.manager.addSceneValue(self.scene_id, value_id, value_data)
         if ret == 1:
             return True
@@ -136,6 +140,9 @@ class ZWaveScene(ZWaveObject):
         :type value_data: variable
 
         """
+        if isstr(value_data):
+            value_data = value_data.encode("UTF-8")
+
         ret = self._network.manager.setSceneValue(self.scene_id, value_id, value_data)
         if ret == 1:
             return True

--- a/api/util.py
+++ b/api/util.py
@@ -1,0 +1,13 @@
+# Python 2/3 compatibilities
+import sys
+
+if sys.hexversion >= 0x3000000:
+    def isstr(s):
+        return isinstance(s, str)
+
+    from pydispatch import dispatcher
+else:
+    def isstr(s):
+        return isinstance(s, basestring)
+
+    from louie import dispatcher

--- a/api/value.py
+++ b/api/value.py
@@ -30,6 +30,7 @@ import openzwave
 import logging
 from threading import Timer
 from openzwave.object import ZWaveObject
+from .util import isstr
 
 logging.getLogger('openzwave').addHandler(logging.NullHandler())
 
@@ -131,7 +132,7 @@ class ZWaveValue(ZWaveObject):
 
         :rtype: str
         """
-        return self._network.manager.getValueLabel(self.value_id)
+        return self._network.manager.getValueLabel(self.value_id).decode("UTF-8")
 
     @label.setter
     def label(self, value):
@@ -141,7 +142,7 @@ class ZWaveValue(ZWaveObject):
         :param value: The new label value
         :type value: str
         """
-        self._network.manager.setValueLabel(self.value_id, value)
+        self._network.manager.setValueLabel(self.value_id, value.encode("UTF-8"))
 
     @property
     def help(self):
@@ -150,7 +151,7 @@ class ZWaveValue(ZWaveObject):
 
         :rtype: str
         """
-        return self._network.manager.getValueHelp(self.value_id)
+        return self._network.manager.getValueHelp(self.value_id).decode("UTF-8")
 
     @help.setter
     def help(self, value):
@@ -161,7 +162,7 @@ class ZWaveValue(ZWaveObject):
         :type value: str
 
         """
-        self._network.manager.setValueHelp(self.value_id, value)
+        self._network.manager.setValueHelp(self.value_id, value.encode("UTF-8"))
 
     @property
     def units(self):
@@ -171,7 +172,7 @@ class ZWaveValue(ZWaveObject):
         :rtype: str
 
         """
-        return self._network.manager.getValueUnits(self.value_id)
+        return self._network.manager.getValueUnits(self.value_id).decode("UTF-8")
 
     @units.setter
     def units(self, value):
@@ -182,7 +183,7 @@ class ZWaveValue(ZWaveObject):
         :type value: str
 
         """
-        self._network.manager.setValueUnits(self.value_id, value)
+        self._network.manager.setValueUnits(self.value_id, value.encode("UTF-8"))
 
     @property
     def max(self):
@@ -266,7 +267,12 @@ class ZWaveValue(ZWaveObject):
         :rtype: depending of the type of the value
 
         """
-        return self._network.manager.getValue(self.value_id)
+        data = self._network.manager.getValue(self.value_id)
+
+        if self.type in ("String", "List"):
+            data = data.decode("UTF-8")
+
+        return data
 
     @data.setter
     def data(self, value):
@@ -283,6 +289,9 @@ class ZWaveValue(ZWaveObject):
         :type value: str
 
         """
+        if self.type == "String":
+            value = value.encode("UTF-8")
+
         self._network.manager.setValue(self.value_id, value)
 
     @property
@@ -342,7 +351,7 @@ class ZWaveValue(ZWaveObject):
         logging.debug("check_data type :%s" % (self.type))
         if self.type == "Bool":
             new_data = data
-            if isinstance(data, basestring) :
+            if isstr(data):
                 if data == "False" or data == "false" or data == "0":
                     new_data = False
                 else :
@@ -383,16 +392,16 @@ class ZWaveValue(ZWaveObject):
                 elif new_data > 32767 :
                     new_data = 32767
         elif self.type == "String":
-                new_data = data
+                new_data = data.encode("UTF-8")
         elif self.type == "Button":
             new_data = data
-            if isinstance(data, basestring) :
+            if isstr(data) :
                 if data == "False" or data == "false" or data == "0":
                     new_data = False
                 else :
                     new_data = True
         elif self.type == "List":
-            if isinstance(data, basestring) :
+            if isstr(data) :
                 if data in self.data_items:
                     new_data = data
                 else :

--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+if [[ $* == *--python3* ]]; then
+  PYEX=python3
+else
+  PYEX=python
+fi
+
 CLEAN=0
 [ "$1" = 'clean' ] && CLEAN=1
 
@@ -18,13 +24,13 @@ cd ..
 echo "-----------------------------------------------------------------"
 echo "|   Build python-openzwave                                      |"
 echo "-----------------------------------------------------------------"
-[ $CLEAN -eq 1 ] && python setup-lib.py clean
-[ $CLEAN -eq 1 ] && python setup-api.py clean
+[ $CLEAN -eq 1 ] && $PYEX setup-lib.py clean
+[ $CLEAN -eq 1 ] && $PYEX setup-api.py clean
 [ $CLEAN -eq 1 ] && rm -Rf build/
 [ $CLEAN -eq 1 ] && rm -Rf docs/_build
 [ $CLEAN -eq 1 ] && rm lib/libopenzwave.cpp
-python setup-lib.py build
-python setup-api.py build
+$PYEX setup-lib.py build
+$PYEX setup-api.py build
 
 #Remove the doc generattion as it fails on Ubuntu 10.04
 #if [ u != $(which sphinx-build)u ] ; then

--- a/compile.sh
+++ b/compile.sh
@@ -6,7 +6,6 @@ CLEAN=0
 echo "-----------------------------------------------------------------"
 echo "|   Build openzwave                                             |"
 echo "-----------------------------------------------------------------"
-rm -Rf openzwave/cpp/src/vers.cpp
 cd openzwave/
 [ $CLEAN -eq 1 ] && make clean
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 CLEAN=0
-[ 'u'$1 == 'uclean' ] && CLEAN=1
+[ "$1" = 'clean' ] && CLEAN=1
 
 echo "-----------------------------------------------------------------"
 echo "|   Build openzwave                                             |"
@@ -9,7 +9,11 @@ echo "-----------------------------------------------------------------"
 rm -Rf openzwave/cpp/src/vers.cpp
 cd openzwave/
 [ $CLEAN -eq 1 ] && make clean
-make
+
+echo "Applying ugly patch to openzwave to work around bug in Cython"
+sed -i '253s/.*//' cpp/src/value_classes/ValueID.h
+
+VERSION_REV=0 make
 cd ..
 
 echo "-----------------------------------------------------------------"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
 
+if [ "$1" == "--python3" ]; then
+  PYEX=python3
+else
+  PYEX=python
+fi
+
 echo "-----------------------------------------------------------------"
 echo "|   Uninstall python-openzwave                                  |"
 echo "-----------------------------------------------------------------"
@@ -10,12 +16,12 @@ set -e
 echo "-----------------------------------------------------------------"
 echo "|   Install python-openzwave  lib                               |"
 echo "-----------------------------------------------------------------"
-python setup-lib.py install --record install.files
+$PYEX setup-lib.py install --record install.files
 
 echo "-----------------------------------------------------------------"
 echo "|   Install python-openzwave  api                               |"
 echo "-----------------------------------------------------------------"
-python setup-api.py install --record install.tmp
+$PYEX setup-api.py install --record install.tmp
 cat install.tmp >>install.files
 rm install.tmp
 rm -Rf python_openzwave_lib.egg-info >/dev/null 2>&1

--- a/setup-api.py
+++ b/setup-api.py
@@ -31,6 +31,11 @@ import glob
 import os
 import sys
 
+if sys.hexversion >= 0x3000000:
+    dispatch_package = 'pydispatcher >= 2.0.5'
+else:
+    dispatch_package = 'Louie >= 1.1'
+
 DEBIAN_PACKAGE = False
 filtered_args = []
 
@@ -74,12 +79,12 @@ setup(
   name = 'python-openzwave-api',
   author='Sébastien GALLET aka bibi2100 <bibi21000@gmail.com>',
   author_email='bibi21000@gmail.com',
-  url='http://code.google.com/p/python-openzwave',
+  url='https://github.com/nechry/python-openzwave',
   #Need to update libopenzwave.pyx too
   version = '0.2.6',
   package_dir = {'openzwave' : 'api', 'pyozwman' : 'manager' },
   #The following line install config drectory in share/python-openzwave
   data_files = data_files,
   packages = ['openzwave', 'pyozwman' ],
-  install_requires=[ 'nose >= 0.8.3', 'Louie >= 1.1' ]
+  install_requires=[ 'nose >= 0.8.3', dispatch_package ]
 )

--- a/setup-lib.py
+++ b/setup-lib.py
@@ -75,7 +75,7 @@ if os_name == 'nt':
                              include_dirs=['openzwave/cpp/src', 'openzwave/cpp/src/value_classes', 'openzwave/cpp/src/platform', 'openzwave/cpp/build/windows']
     )]
 elif platform_system() == 'Darwin':
-    ext_modules = [Extension("libopenzwave", ["lib/libopenzwave.pyx"],
+    ext_modules = [extension.Extension("libopenzwave", ["lib/libopenzwave.pyx"],
                              libraries=['stdc++'],
                              language="c++",
                              extra_link_args=['-framework', 'CoreFoundation', '-framework', 'IOKit'],
@@ -83,7 +83,7 @@ elif platform_system() == 'Darwin':
                              include_dirs=['openzwave/cpp/src', 'openzwave/cpp/src/value_classes', 'openzwave/cpp/src/platform', 'openzwave/cpp/build/mac']
     )]
 elif DEBIAN_PACKAGE == True:
-    ext_modules = [Extension("libopenzwave", ["lib/libopenzwave.pyx"],
+    ext_modules = [extension.Extension("libopenzwave", ["lib/libopenzwave.pyx"],
                              libraries=['udev', 'stdc++', 'openzwave'],
                              language="c++",
                              extra_objects=['/usr/libopenzwave.a'],

--- a/update.sh
+++ b/update.sh
@@ -3,19 +3,12 @@
 echo "-----------------------------------------------------------------"
 echo "|   Update sources of python-openzwave                          |"
 echo "-----------------------------------------------------------------"
-hg pull https://code.google.com/p/python-openzwave/
-hg update
+git pull
 
 echo "-----------------------------------------------------------------"
 echo "|   Update sources of openzwave                                 |"
 echo "-----------------------------------------------------------------"
-if [ -d openzwave ] ; then
-    echo "Update openzwave directory"
-    svn update openzwave
-else
-    echo "Checkout openzwave directory"
-    svn checkout http://open-zwave.googlecode.com/svn/trunk/ openzwave
-fi
+git submodule update --init --recursive
 
 echo "-----------------------------------------------------------------"
 echo "|   Sources updated                                             |"


### PR DESCRIPTION
This pull request adds Python 3 support to Python Open Z-Wave.

Compile and install scripts have been updated too. By default it will use Python 2, add `--python3` as a command line argument to compile or install for Python 3.